### PR TITLE
Add author_id to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@
 /lib/redmine/scm/adapters/mercurial/redminehelper.pyo
 /log/*.log*
 /log/mongrel_debug
-/plugins/*
-!/plugins/README
 /public/assets/*
 /public/dispatch.*
 /public/plugin_assets/*

--- a/plugins/author_selector/app/controllers/projects_controller_patch.rb
+++ b/plugins/author_selector/app/controllers/projects_controller_patch.rb
@@ -1,0 +1,20 @@
+module AuthorSelector
+  module Patches
+    module ProjectsControllerPatch
+      def self.included(base)
+        base.class_eval do
+          before_action :add_author_to_project, only: [:create, :update]
+        end
+      end
+
+      def add_author_to_project
+        binding.break
+        if params[:project] && params[:project][:author_id].present?
+          @project.author_id = params[:project][:author_id]
+        end
+      end
+    end
+  end
+end
+
+ProjectsController.include AuthorSelector::Patches::ProjectsControllerPatch

--- a/plugins/author_selector/app/models/project_patch.rb
+++ b/plugins/author_selector/app/models/project_patch.rb
@@ -1,0 +1,13 @@
+module AuthorSelector
+  module Patches
+    module ProjectPatch
+      def self.included(base)
+        base.class_eval do
+          belongs_to :author, class_name: 'User', foreign_key: 'author_id'
+        end
+      end
+    end
+  end
+end
+
+Project.include AuthorSelector::Patches::ProjectPatch

--- a/plugins/author_selector/app/views/projects/_form.html.erb
+++ b/plugins/author_selector/app/views/projects/_form.html.erb
@@ -1,0 +1,68 @@
+<%= error_messages_for 'project' %>
+
+<div class="box tabular">
+<!--[form:project]-->
+<p><%= f.text_field :name, :required => true, :size => 60 %></p>
+
+<p><%= f.text_area :description, :rows => 8, :class => 'wiki-edit' %></p>
+<p><%= f.text_field :identifier, :required => true, :size => 60, :disabled => @project.identifier_frozen?, :maxlength => Project::IDENTIFIER_MAX_LENGTH %>
+<% unless @project.identifier_frozen? %>
+  <em class="info"><%= l(:text_length_between, :min => 1, :max => Project::IDENTIFIER_MAX_LENGTH) %> <%= l(:text_project_identifier_info).html_safe %></em>
+<% end %></p>
+<p><%= f.text_field :homepage, :size => 60 %></p>
+<p>
+  <%= f.check_box :is_public, :disabled => !@project.safe_attribute?(:is_public) %>
+  <em class="info"><%= Setting.login_required? ? l(:text_project_is_public_non_member) : l(:text_project_is_public_anonymous) %></em>
+</p>
+
+<!--Author_id select-->
+<p><%= f.select :author_id, options_from_collection_for_select(User.all, :id, :name, @project.author_id), include_blank: true, label: l(:label_author) %></p>
+
+<% unless @project.allowed_parents.compact.empty? %>
+    <p><%= label(:project, :parent_id, l(:field_parent)) %><%= parent_project_select_tag(@project) %></p>
+<% end %>
+
+<% if @project.safe_attribute? 'inherit_members' %>
+<p><%= f.check_box :inherit_members %></p>
+<% end %>
+
+<%= wikitoolbar_for 'project_description' %>
+
+<% @project.visible_custom_field_values.each do |value| %>
+  <p><%= custom_field_tag_with_label :project, value %></p>
+<% end %>
+<%= call_hook(:view_projects_form, :project => @project, :form => f) %>
+</div>
+
+<% if @project.safe_attribute?('enabled_module_names') %>
+<fieldset class="box tabular" id="project_modules"><legend><%= toggle_checkboxes_link('#project_modules input[type="checkbox"]') %><%= l(:label_module_plural) %></legend>
+<% Redmine::AccessControl.available_project_modules.each do |m| %>
+    <label class="floating">
+    <%= check_box_tag 'project[enabled_module_names][]', m, @project.module_enabled?(m), :id => "project_enabled_module_names_#{m}" %>
+    <%= l_or_humanize(m, :prefix => "project_module_") %>
+    </label>
+<% end %>
+<%= hidden_field_tag 'project[enabled_module_names][]', '' %>
+</fieldset>
+<% end %>
+<!--[eoform:project]-->
+
+<% unless @project.identifier_frozen? %>
+  <% content_for :header_tags do %>
+    <%= javascript_include_tag 'project_identifier' %>
+  <% end %>
+<% end %>
+
+<% if !User.current.admin? && @project.inherit_members? && @project.parent && User.current.member_of?(@project.parent) %>
+  <%= javascript_tag do %>
+    $(document).ready(function() {
+      $("#project_inherit_members").change(function(){
+        if (!$(this).is(':checked')) {
+          if (!confirm("<%= escape_javascript(l(:text_own_membership_delete_confirmation)) %>")) {
+            $("#project_inherit_members").attr("checked", true);
+          }
+        }
+      });
+    });
+  <% end %>
+<% end %>

--- a/plugins/author_selector/config/locales/cs.yml
+++ b/plugins/author_selector/config/locales/cs.yml
@@ -1,0 +1,2 @@
+cs:
+  label_author: 'Autor'

--- a/plugins/author_selector/config/locales/en.yml
+++ b/plugins/author_selector/config/locales/en.yml
@@ -1,0 +1,2 @@
+en:
+  label_author: 'Author'

--- a/plugins/author_selector/db/migrate/20240824123458_add_author_ref_to_projects.rb
+++ b/plugins/author_selector/db/migrate/20240824123458_add_author_ref_to_projects.rb
@@ -1,0 +1,15 @@
+class AddAuthorRefToProjects < ActiveRecord::Migration[7.1]
+  def up
+    add_reference :projects, :author, foreign_key: { to_table: :users }
+  end
+
+  def down
+    if foreign_key_exists?(:projects, :author_id)
+      remove_foreign_key :projects, column: :author_id
+    end
+
+    if column_exists?(:projects, :author_id)
+      remove_column :projects, :author_id
+    end
+  end
+end

--- a/plugins/author_selector/init.rb
+++ b/plugins/author_selector/init.rb
@@ -1,0 +1,14 @@
+Redmine::Plugin.register :author_selector do
+  name 'Author Selector Plugin'
+  author 'veronicie'
+  description 'This plugin adds an option to select an author for a project from already registered users.'
+  version '0.0.1'
+  requires_redmine version_or_higher: '4.0.0'
+end
+
+Rails.configuration.to_prepare do
+  require_dependency 'projects_controller_patch'
+  require_dependency 'project_patch'
+  ProjectsController.include AuthorSelector::ProjectsControllerPatch
+  Project.include AuthorSelector::ProjectPatch
+end

--- a/plugins/author_selector/test/functional/projects_controller_patch_test.rb
+++ b/plugins/author_selector/test/functional/projects_controller_patch_test.rb
@@ -1,0 +1,41 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class ProjectsControllerPatchTest < ActionController::TestCase
+  fixtures :projects, :users
+
+  def setup
+    @controller = ProjectsController.new
+    @request = ActionController::TestRequest.create
+    @response = ActionController::TestResponse.create
+
+    ProjectsController.include AuthorSelector::Patches::ProjectsControllerPatch
+  end
+
+  def test_should_set_author_on_project_create
+    user = User.find(1)
+
+    post :create, params: {
+      project: {
+        name: 'Test Project',
+        identifier: 'test-project',
+        author_id: user.id
+      }
+    }
+
+    project = Project.last
+    assert_equal user, project.author
+  end
+
+  def test_should_update_author_on_project_update
+    project = Project.find(1)
+    user = User.find(1)
+
+    patch :update, params: {
+      id: project.id,
+      project: { author_id: user.id }
+    }
+
+    project.reload
+    assert_equal user, project.author
+  end
+end

--- a/plugins/author_selector/test/test_helper.rb
+++ b/plugins/author_selector/test/test_helper.rb
@@ -1,0 +1,1 @@
+require File.expand_path('../../../../test/test_helper', __FILE__)

--- a/plugins/author_selector/test/unit/project_patch_test.rb
+++ b/plugins/author_selector/test/unit/project_patch_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class ProjectPatchTest < ActiveSupport::TestCase
+  fixtures :projects, :users
+
+  def setup
+    Project.include AuthorSelector::Patches::ProjectPatch
+  end
+
+  def test_project_should_have_author_association
+    project = Project.new(name: 'Test Project', identifier: 'test-project')
+    user = User.find(1)
+
+    project.author = user
+    assert_equal user, project.author
+  end
+end


### PR DESCRIPTION
I am submitting my attempt at creating a Redmine plugin that adds the author_id field to existing projects.

While I successfully registered the plugin, as it appears in the Administration > Plugins section, I encountered issues loading the controller and model patches. Despite multiple attempts, the patches did not apply correctly, preventing the desired functionality from being fully implemented.

I am including the current state of my code for review and would appreciate any feedback or guidance on how to resolve the patch loading issue.